### PR TITLE
Build Time Info for Field Debugging

### DIFF
--- a/FormatAndLintExample.xcodeproj/project.pbxproj
+++ b/FormatAndLintExample.xcodeproj/project.pbxproj
@@ -6,6 +6,20 @@
 	objectVersion = 55;
 	objects = {
 
+/* Begin PBXAggregateTarget section */
+		3824B2F3282A236D00CC69BF /* BuildVersioning */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = 3824B2F4282A236D00CC69BF /* Build configuration list for PBXAggregateTarget "BuildVersioning" */;
+			buildPhases = (
+				3824B2F7282A237300CC69BF /* ShellScript */,
+			);
+			dependencies = (
+			);
+			name = BuildVersioning;
+			productName = BuildVersioning;
+		};
+/* End PBXAggregateTarget section */
+
 /* Begin PBXBuildFile section */
 		3824B2BF282A123100CC69BF /* FormatAndLintExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3824B2BE282A123100CC69BF /* FormatAndLintExampleApp.swift */; };
 		3824B2C1282A123100CC69BF /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3824B2C0282A123100CC69BF /* ContentView.swift */; };
@@ -14,6 +28,7 @@
 		3824B2D0282A123200CC69BF /* FormatAndLintExampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3824B2CF282A123200CC69BF /* FormatAndLintExampleTests.swift */; };
 		3824B2DA282A123200CC69BF /* FormatAndLintExampleUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3824B2D9282A123200CC69BF /* FormatAndLintExampleUITests.swift */; };
 		3824B2DC282A123200CC69BF /* FormatAndLintExampleUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3824B2DB282A123200CC69BF /* FormatAndLintExampleUITestsLaunchTests.swift */; };
+		3824B2F2282A225D00CC69BF /* Bundle+VersionHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3824B2F1282A225D00CC69BF /* Bundle+VersionHelper.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -31,6 +46,13 @@
 			remoteGlobalIDString = 3824B2BA282A123100CC69BF;
 			remoteInfo = FormatAndLintExample;
 		};
+		3824B2F8282A239A00CC69BF /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 3824B2B3282A123100CC69BF /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3824B2F3282A236D00CC69BF;
+			remoteInfo = BuildVersioning;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
@@ -44,6 +66,7 @@
 		3824B2D5282A123200CC69BF /* FormatAndLintExampleUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FormatAndLintExampleUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3824B2D9282A123200CC69BF /* FormatAndLintExampleUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormatAndLintExampleUITests.swift; sourceTree = "<group>"; };
 		3824B2DB282A123200CC69BF /* FormatAndLintExampleUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormatAndLintExampleUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		3824B2F1282A225D00CC69BF /* Bundle+VersionHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+VersionHelper.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -75,6 +98,7 @@
 			isa = PBXGroup;
 			children = (
 				3824B2BD282A123100CC69BF /* FormatAndLintExample */,
+				3824B2F0282A222700CC69BF /* Util */,
 				3824B2CE282A123200CC69BF /* FormatAndLintExampleTests */,
 				3824B2D8282A123200CC69BF /* FormatAndLintExampleUITests */,
 				3824B2BC282A123100CC69BF /* Products */,
@@ -127,6 +151,14 @@
 			path = FormatAndLintExampleUITests;
 			sourceTree = "<group>";
 		};
+		3824B2F0282A222700CC69BF /* Util */ = {
+			isa = PBXGroup;
+			children = (
+				3824B2F1282A225D00CC69BF /* Bundle+VersionHelper.swift */,
+			);
+			path = Util;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -145,6 +177,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				3824B2F9282A239A00CC69BF /* PBXTargetDependency */,
 			);
 			name = FormatAndLintExample;
 			productName = FormatAndLintExample;
@@ -209,6 +242,9 @@
 						CreatedOnToolsVersion = 13.3.1;
 						TestTargetID = 3824B2BA282A123100CC69BF;
 					};
+					3824B2F3282A236D00CC69BF = {
+						CreatedOnToolsVersion = 13.3.1;
+					};
 				};
 			};
 			buildConfigurationList = 3824B2B6282A123100CC69BF /* Build configuration list for PBXProject "FormatAndLintExample" */;
@@ -227,6 +263,7 @@
 				3824B2BA282A123100CC69BF /* FormatAndLintExample */,
 				3824B2CA282A123200CC69BF /* FormatAndLintExampleTests */,
 				3824B2D4282A123200CC69BF /* FormatAndLintExampleUITests */,
+				3824B2F3282A236D00CC69BF /* BuildVersioning */,
 			);
 		};
 /* End PBXProject section */
@@ -274,7 +311,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Requires SwiftFormat to be installed on the system.\n\n# Add to PATH for Homebrew (Intel), Homebrew (Apple Silicon), Mint. \nexport PATH=\"/usr/local/bin/:/opt/homebrew/:~/.mint/bin/:$PATH\"\n \nif command -v swiftformat >/dev/null 2>&1; then\n    swiftformat \"$SRCROOT\"\nelse\n    echo \"swiftformat is not installed.\" >&2 \n    echo \"==> Install from https://github.com/nicklockwood/SwiftFormat\" >&2\n    # exit 1\nfi\n";
+			shellScript = "# Requires SwiftFormat to be installed on the system.\n\n# Add to PATH for Homebrew (Intel), Homebrew (Apple Silicon), Mint. \nexport PATH=\"/usr/local/bin/:/opt/homebrew/:$HOME/.mint/bin/:$PATH\"\n \nif command -v swiftformat >/dev/null 2>&1; then\n    swiftformat \"$SRCROOT\"\nelse\n    echo \"swiftformat is not installed.\" >&2 \n    echo \"==> Install from https://github.com/nicklockwood/SwiftFormat\" >&2\n    # exit 1\nfi\n";
 		};
 		3824B2E9282A12E900CC69BF /* ✳️ Format Not Installed */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -310,7 +347,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "#export PATH=\"/usr/local/bin/:/opt/homebrew/:~/.mint/bin/:$PATH\"\n \n#if command -v swiftformat >/dev/null 2>&1; then\n#    swiftformat \"$SRCROOT\"\n#else\n#    echo \"swiftformat is not installed.\" >&2 \n#    echo \"==> Install from https://github.com/nicklockwood/SwiftFormat\" >&2\n#    # exit 1\n#fi\n";
+			shellScript = "#export PATH=\"/usr/local/bin/:/opt/homebrew/:$HOME/.mint/bin/:$PATH\"\n \n#if command -v swiftformat >/dev/null 2>&1; then\n#    swiftformat \"$SRCROOT\"\n#else\n#    echo \"swiftformat is not installed.\" >&2 \n#    echo \"==> Install from https://github.com/nicklockwood/SwiftFormat\" >&2\n#    # exit 1\n#fi\n";
 		};
 		3824B2EE282A183600CC69BF /* ✅ Lint with SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -346,7 +383,24 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export PATH=\"/usr/local/bin/:/opt/homebrew/:~/.mint/bin/:$PATH\"\n \nif command -v swiftformat >/dev/null 2>&1; then\n    swiftformat --lint --lenient \"$SRCROOT\"\nelse\n    echo \"swiftformat is not installed.\" >&2 \n    echo \"==> Install from https://github.com/nicklockwood/SwiftFormat\" >&2\n    # exit 1\nfi\n";
+			shellScript = "export PATH=\"/usr/local/bin/:/opt/homebrew/:$HOME/.mint/bin/:$PATH\"\n \nif command -v swiftformat >/dev/null 2>&1; then\n    swiftformat --lint --lenient \"$SRCROOT\"\nelse\n    echo \"swiftformat is not installed.\" >&2 \n    echo \"==> Install from https://github.com/nicklockwood/SwiftFormat\" >&2\n    # exit 1\nfi\n";
+		};
+		3824B2F7282A237300CC69BF /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "./Scripts/build_versioning.sh\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -355,6 +409,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3824B2F2282A225D00CC69BF /* Bundle+VersionHelper.swift in Sources */,
 				3824B2C1282A123100CC69BF /* ContentView.swift in Sources */,
 				3824B2BF282A123100CC69BF /* FormatAndLintExampleApp.swift in Sources */,
 			);
@@ -389,6 +444,11 @@
 			isa = PBXTargetDependency;
 			target = 3824B2BA282A123100CC69BF /* FormatAndLintExample */;
 			targetProxy = 3824B2D6282A123200CC69BF /* PBXContainerItemProxy */;
+		};
+		3824B2F9282A239A00CC69BF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 3824B2F3282A236D00CC69BF /* BuildVersioning */;
+			targetProxy = 3824B2F8282A239A00CC69BF /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -443,6 +503,9 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = FormatAndLintExample/Info.plist;
+				INFOPLIST_PREFIX_HEADER = InfoPlist.h;
+				INFOPLIST_PREPROCESS = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -497,6 +560,9 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = FormatAndLintExample/Info.plist;
+				INFOPLIST_PREFIX_HEADER = InfoPlist.h;
+				INFOPLIST_PREPROCESS = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
@@ -641,6 +707,24 @@
 			};
 			name = Release;
 		};
+		3824B2F5282A236D00CC69BF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 825MF8C7NT;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		3824B2F6282A236D00CC69BF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 825MF8C7NT;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -676,6 +760,15 @@
 			buildConfigurations = (
 				3824B2E6282A123200CC69BF /* Debug */,
 				3824B2E7282A123200CC69BF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3824B2F4282A236D00CC69BF /* Build configuration list for PBXAggregateTarget "BuildVersioning" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3824B2F5282A236D00CC69BF /* Debug */,
+				3824B2F6282A236D00CC69BF /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/FormatAndLintExample.xcodeproj/xcshareddata/xcschemes/FormatAndLintExample.xcscheme
+++ b/FormatAndLintExample.xcodeproj/xcshareddata/xcschemes/FormatAndLintExample.xcscheme
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1330"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3824B2BA282A123100CC69BF"
+               BuildableName = "FormatAndLintExample.app"
+               BlueprintName = "FormatAndLintExample"
+               ReferencedContainer = "container:FormatAndLintExample.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3824B2CA282A123200CC69BF"
+               BuildableName = "FormatAndLintExampleTests.xctest"
+               BlueprintName = "FormatAndLintExampleTests"
+               ReferencedContainer = "container:FormatAndLintExample.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3824B2D4282A123200CC69BF"
+               BuildableName = "FormatAndLintExampleUITests.xctest"
+               BlueprintName = "FormatAndLintExampleUITests"
+               ReferencedContainer = "container:FormatAndLintExample.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3824B2BA282A123100CC69BF"
+            BuildableName = "FormatAndLintExample.app"
+            BlueprintName = "FormatAndLintExample"
+            ReferencedContainer = "container:FormatAndLintExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "OS_ACTIVITY_MODE"
+            value = "disable"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3824B2BA282A123100CC69BF"
+            BuildableName = "FormatAndLintExample.app"
+            BlueprintName = "FormatAndLintExample"
+            ReferencedContainer = "container:FormatAndLintExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/FormatAndLintExample/ContentView.swift
+++ b/FormatAndLintExample/ContentView.swift
@@ -7,15 +7,101 @@
 
 import SwiftUI
 
+extension View {
+    func viewPrint(_ vars: Any...) -> some View {
+        _ = vars.map { print($0) }
+        return EmptyView()
+    }
+}
+
 struct ContentView: View {
     var body: some View {
-        Text("Hello, world!")
-            .padding()
+        viewPrint("Environment: \(Bundle.envInfo)") // large!
+        List {
+            BuildInfo()
+            GitInfo()
+            ToolInfo()
+            HStack {
+                Text("Host info:")
+                Spacer()
+                Text("\(Bundle.hostInfo)")
+            }
+        }
     }
 }
 
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
         ContentView()
+    }
+}
+
+struct BuildInfo: View {
+    var body: some View {
+        HStack {
+            Text("UTC build time:")
+            Spacer()
+            Text("\(Bundle.buildTime)")
+        }
+        HStack {
+            Text("UTC build date:")
+            Spacer()
+            Text("\(Bundle.buildDate)")
+        }
+        HStack {
+            Text("Build number:")
+            Spacer()
+            Text("\(Bundle.buildNumber)")
+        }
+        HStack {
+            Text("Version number:")
+            Spacer()
+            Text("\(Bundle.marketingVersion)")
+        }
+    }
+}
+
+struct GitInfo: View {
+    var body: some View {
+        HStack {
+            Text("Git commit count:")
+            Spacer()
+            Text("\(Bundle.gitCommitCount)")
+        }
+        HStack {
+            Text("Git branch:")
+            Spacer()
+            Text("\(Bundle.gitBranch)")
+        }
+        HStack {
+            Text("Git SHA:")
+            Spacer()
+            Text("\(Bundle.gitSha)")
+        }
+    }
+}
+
+struct ToolInfo: View {
+    var body: some View {
+        HStack {
+            Text("xcodebuild version:")
+            Spacer()
+            Text("\(Bundle.xcodeBuildVersion)")
+        }
+        HStack {
+            Text("xcode-select version:")
+            Spacer()
+            Text("\(Bundle.xcodeSelectVersion)")
+        }
+        HStack {
+            Text("xcrun version:")
+            Spacer()
+            Text("\(Bundle.xcrunVersion)")
+        }
+        HStack {
+            Text("Clang version:")
+            Spacer()
+            Text("\(Bundle.clangVersion)")
+        }
     }
 }

--- a/FormatAndLintExample/Info.plist
+++ b/FormatAndLintExample/Info.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>XKEY_CLANG_VERSION</key>
+	<string>X_CLANG_VERSION</string>
+	<key>XKEY_ENV_INFO</key>
+	<string>X_ENV_INFO</string>
+	<key>XKEY_GIT_BRANCH</key>
+	<string>X_GIT_BRANCH</string>
+	<key>XKEY_GIT_COMMIT_COUNT</key>
+	<string>X_GIT_COMMIT_COUNT</string>
+	<key>XKEY_GIT_HASH</key>
+	<string>X_GIT_HASH</string>
+	<key>XKEY_PKGUTIL_INFO</key>
+	<string>X_PKGUTIL_INFO</string>
+	<key>XKEY_UNAME_INFO</key>
+	<string>X_UNAME_INFO</string>
+	<key>XKEY_UTC_BUILD_DATE</key>
+	<string>X_UTC_BUILD_DATE</string>
+	<key>XKEY_UTC_BUILD_TIME</key>
+	<string>X_UTC_BUILD_TIME</string>
+	<key>XKEY_XCODE_BUILD_VERSION</key>
+	<string>X_XCODE_BUILD_VERSION</string>
+	<key>XKEY_XCODE_SELECT_VERSION</key>
+	<string>X_XCODE_SELECT_VERSION</string>
+	<key>XKEY_XCRUN_VERSION</key>
+	<string>X_XCRUN_VERSION</string>
+</dict>
+</plist>

--- a/Scripts/build_versioning.sh
+++ b/Scripts/build_versioning.sh
@@ -1,0 +1,202 @@
+#!/bin/sh
+### Purpose:
+#
+# Sets the commit count to the git revision number.
+#     This helps with keeping versions distinct in tools like TestFlight, Crashlytics, HockeyApp,
+#     and can be used as a form of build number.
+# Sets the current git commit SHA in the app, including marking it with a "+" suffix
+#     if there are uncommited changes.
+#     This helps with traceability.
+# Sets the date and time of the build to the month, day, hour, and minutes (no seconds).
+#     This makes checking for the freshness of a build more human-friendly.
+# Sets other version information from the environment at build time.
+#     This make this info available to help with troubleshooting. 
+#
+# This uses prefixes (error:, warning:, note:) for some echo statements for Xcode parsing. 
+
+### One-time set up:
+#
+## For Visual Studio Code: 
+#
+# 0. Uncomment the Flutter and Dart lines in this script, and change output from Info.plist to a Dart file.
+# 1. Create a tasks.json file (next to vscode's launch.json, usually in the workspace's .vscode directory).
+# 2. Put this task definition into it: 
+# {
+#     "type": "shell",
+#     "command": "./scripts/build_versioning.sh",
+#     "args": [],
+#     "group": {
+#         "kind": "build",
+#         "isDefault": true
+#     },
+#     "problemMatcher": [],
+#     "label": "flutter: build versioning"
+# }
+# 3. Add `"preLaunchTask": "flutter: build versioning"` to launch.json configuration(s) to reference the task.
+#
+#
+## For Android Studio / Jetbrains IDEs:
+#
+# 0. Uncomment the Flutter and Dart lines in this script, and change output from Info.plist to a Dart file.
+# 1. Go to `Run > Edit Configurations`
+# 2. Add a new shell script / external tool configuration to invoke this script.
+# 3. Configure our normal configuration(s) with a `Before Launch` to invoke the new shell script config.
+#
+#
+## For Xcode: 
+#
+# 1. Enable "Preprocess Info.plist File" (INFOPLIST_PREPROCESS) in the primary target's
+# Build Settings (under the "Packaging" section, with 'All' settings visible).
+#
+# 2. Set "Info.plist Preprocessor Prefix File" (INFOPLIST_PREFIX_HEADER) to InfoPlist.h.
+#
+# 3. Add InfoPlist.h to the project's git ignore file (as it is generated here).
+#
+# 4. Add a new Other | Aggregate target with a 'Build Phases - Run Script' of "./Scripts/build_versioning.sh".
+#
+# 5. Add the new target as a dependency of the primary build target (under 'Build Phases').
+#
+# 6. Add XKEY_BUILD_NUMBER:X_GIT_COMMIT_COUNT as a string value to your Info.plist
+# (key from VersionHelper, value as the plain name of the #define below).
+#
+# 7. Repeat step 6 for the other values.
+#
+# This is being used with VersionHelper.swift for display in the UI. 
+
+echo "note: Executing $0 $*"
+
+# Ensure that Homebrew (Intel and Apple Silicon) and Mint are on the PATH. 
+PATH="/usr/local/bin/:/opt/homebrew/:$HOME/.mint/bin/:$PATH"
+
+# Refresh local git status
+git fetch origin --unshallow --no-tags -q > /dev/null 2>&1
+
+# Get dynamic values. 
+#
+# Some require a little additional processing,
+# such as combining multiple lines into a single line, 
+# extracting portions of the command output, 
+# or trimming trailing whitespace or periods.
+
+if hash flutter 2>/dev/null; then
+    flutter_version=$(flutter --version | sed -n 's/^\(Flutter\ [0-9\.a-z-]*\)\ .*$/\1/p')
+    dart_version=$(flutter --version | sed -n 's/Tools.*\(Dart\ [^\ ]*\).*$/\1/p')
+else
+    echo "Flutter not installed (or not on PATH)"
+fi
+
+if hash java 2>/dev/null; then
+    java_version=$(TEMP="$(java --version | perl -pe's/\n/ /g' | perl -pe'chop')" && echo "$TEMP")
+else
+    echo "Java not installed (or not on PATH)"
+fi
+
+utc_build_date=$(date -u '+%Y/%m/%d')
+utc_build_time=$(date -u '+%H:%M')
+rev_number=$(git rev-list --count HEAD)
+git_hash=$(git rev-parse --short HEAD)
+git_branch=$(git rev-parse --abbrev-ref HEAD)
+uname_info=$(uname -a)
+xcrun_version=$(xcrun --version | perl -pe's/\.$//g' | perl -pe's/.*version\ (.*)/$1/')
+xcode_select_version=$(xcode-select --version | perl -pe's/\.$//g' | perl -pe's/.*version\ (.*)/$1/')
+xcode_build_version=$(TEMP="$(xcodebuild -version | perl -pe's/\n/ /g' | perl -pe'chop')" && echo "$TEMP")
+clang_version=$(TEMP="$(clang --version | perl -pe's/\n/ /g' | perl -pe'chop')" && echo "$TEMP")
+pkgutil_info=$(TEMP="$(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | perl -pe's/\n/ /g' | perl -pe'chop' | perl -pe'chop')" && echo "$TEMP")
+env_info=$(TEMP="$(env | perl -pe's/\n/ /g' | perl -pe'chop')" && echo "$TEMP")
+
+echo "note: BUILD VERSIONING:"
+echo "note:    utc_build_date = $utc_build_date"
+echo "note:    utc_build_time = $utc_build_time"
+echo "note:    rev_number = $rev_number"
+echo "note:    git_hash = $git_hash"
+echo "note:    git_branch = $git_branch"
+echo "note:    xcrun_version = $xcrun_version"
+echo "note:    xcode_select_version = $xcode_select_version"
+echo "note:    xcode_build_version = $xcode_build_version"
+echo "note:    clang_version = $clang_version"
+echo "note:    pkgutil_info = $pkgutil_info"
+echo "note:    uname_info = $uname_info"
+echo "note:    env_info = $env_info"
+echo "    flutter_version = $flutter_version"
+echo "    dart_version = $dart_version"
+echo "    java_version = $java_version"
+
+if ! [ "$PROJECT_NAME" ]; then
+    echo "error: PROJECT_NAME not defined."
+    echo "error: This must be run from within Xcode (or have PROJECT_NAME manually defined)."
+    echo "error: Aborting"
+    exit 1
+fi
+
+# TODO: flip on this or the other
+generate_dart_file()
+{
+    scripts_dir=$(dirname "$0")
+    # Use this auto-generated and git-ignored file at runtime to access these build-time values.
+    output_file="$scripts_dir/../lib/GeneratedInfo.dart"
+    {
+        echo "/// This file is generated. Do not edit." 
+        echo "///" 
+        echo "/// See Scripts/build_versioning.sh for details." 
+        echo "struct GeneratedInfo {" 
+    } > "$output_file";
+    if [ "$(git status | grep "nothing to commit" > /dev/null 2>&1;)" = "0" ]; then
+        echo "  static const String X_GIT_HASH = '$git_hash+';" >> "$output_file";
+    else
+        echo "  static const String X_GIT_HASH = '$git_hash';" >> "$output_file";
+    fi
+    {
+        echo "  static const String X_GIT_COMMIT_COUNT = '$rev_number';"
+        echo "  static const String X_GIT_BRANCH = '$git_branch';"
+        echo "  static const String X_BUILD_DATE = '$utc_build_date';"
+        echo "  static const String X_BUILD_TIME = '$utc_build_time';"
+        echo "  static const String X_FLUTTER_VERSION = '$flutter_version';"
+        echo "  static const String X_DART_VERSION = '$dart_version';"
+        echo "}"
+    } >> "$output_file";
+
+    echo "note: Wrote to '$output_file'"
+}
+
+generate_header_file()
+{
+    scripts_dir=$(dirname "$0")
+
+    # Use this auto-generated and git-ignored file (with VersionHelper.swift) at runtime to access these build-time values.
+    # This has the advantage of avoiding changes in git for simple version updates, 
+    # compared to direct Plist modification via PListBuddy.
+    output_file="$scripts_dir/../InfoPlist.h"
+    {
+        echo "// This file is generated. Do not edit." 
+        echo "//" 
+        echo "// See Scripts/build_versioning.sh for details." 
+        echo " "
+    } > "$output_file";
+    if [ "$(git status | grep "nothing to commit" > /dev/null 2>&1;)" = "0" ]; then
+        echo "#define X_GIT_HASH $git_hash+" >> "$output_file";
+    else
+        echo "#define X_GIT_HASH $git_hash" >> "$output_file";
+    fi
+    {
+        echo "#define X_UTC_BUILD_DATE $utc_build_date"
+        echo "#define X_UTC_BUILD_TIME $utc_build_time"
+        echo "#define X_GIT_COMMIT_COUNT $rev_number"
+        echo "#define X_GIT_BRANCH $git_branch"
+        echo "#define X_XCRUN_VERSION $xcrun_version"
+        echo "#define X_XCODE_SELECT_VERSION $xcode_select_version"
+        echo "#define X_XCODE_BUILD_VERSION $xcode_build_version"
+        echo "#define X_CLANG_VERSION $clang_version"
+        echo "#define X_PKGUTIL_INFO $pkgutil_info"
+        echo "#define X_UNAME_INFO $uname_info"
+        echo "#define X_ENV_INFO $env_info"
+        echo "#define CURRENT_PROJECT_VERSION $rev_number"
+        echo ""
+    } >> "$output_file";
+
+    # Let Xcode know that the PList has changed so it will reload it, expanding with the updated values.
+    touch "$scripts_dir/../$PROJECT_NAME/Info.plist"
+
+    echo "note: Wrote to '$output_file'"
+}
+
+generate_header_file

--- a/Util/Bundle+VersionHelper.swift
+++ b/Util/Bundle+VersionHelper.swift
@@ -1,0 +1,48 @@
+//
+//  VersionHelper.swift
+//
+//  Copyright (c) 2015 Method Up LLC. All rights reserved.
+//
+
+import Foundation
+
+/**
+ * Simple helper for the various parts of version information for a given build.
+ *
+ * Collected right before compilation.
+ */
+extension Bundle {
+    static let buildNumber: String = infoDictionaryValueFor(key: "CFBundleVersion")
+
+    static let marketingVersion: String = infoDictionaryValueFor(key: "CFBundleShortVersionString")
+
+    static let buildDate: String = infoDictionaryValueFor(key: "XKEY_UTC_BUILD_DATE")
+
+    static let buildTime: String = infoDictionaryValueFor(key: "XKEY_UTC_BUILD_TIME")
+
+    static let gitSha: String = infoDictionaryValueFor(key: "XKEY_GIT_HASH")
+
+    static let gitBranch: String = infoDictionaryValueFor(key: "XKEY_GIT_BRANCH")
+
+    static let gitCommitCount: String = infoDictionaryValueFor(key: "XKEY_GIT_COMMIT_COUNT")
+
+    static let xcodeBuildVersion: String = infoDictionaryValueFor(key: "XKEY_XCODE_BUILD_VERSION")
+
+    static let xcodeSelectVersion: String = infoDictionaryValueFor(key: "XKEY_XCODE_SELECT_VERSION")
+
+    static let xcrunVersion: String = infoDictionaryValueFor(key: "XKEY_XCRUN_VERSION")
+
+    static let clangVersion: String = infoDictionaryValueFor(key: "XKEY_CLANG_VERSION")
+
+    static let pkgutilInfo: String = infoDictionaryValueFor(key: "XKEY_PKGUTIL_INFO")
+
+    static let hostInfo: String = infoDictionaryValueFor(key: "XKEY_UNAME_INFO")
+
+    static let envInfo: String = infoDictionaryValueFor(key: "XKEY_ENV_INFO")
+}
+
+private func infoDictionaryValueFor(key: String) -> String {
+    // swiftlint:disable force_cast
+    (Bundle.main.infoDictionary![key] ?? "") as! String
+    // swiftlint:enable force_cast
+}


### PR DESCRIPTION
# Example / Demo: gathers information from when the archive was built. 

## Added build-time info.

- for field debugging
- plus UI to show it

## Disabled OS_ACTIVITY_MODE

- on run scheme
- to silence console noise (which can't be addressed anyway)

